### PR TITLE
Format amount on invoice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 .env
 .yarn
 yarn.lock
+*.swp

--- a/src/commands/slash/Utility/solicitar.js
+++ b/src/commands/slash/Utility/solicitar.js
@@ -10,6 +10,7 @@ const ExtendedClient = require("../../../class/ExtendedClient");
 const UserManager = require(`../../../class/UserManager.js`);
 const UserWallet = require(`../../../class/User.js`);
 const { AuthorConfig } = require("../../../utils/helperConfig");
+const { formatter } = require("../../../utils/helperFormatter");
 
 module.exports = {
   structure: new SlashCommandBuilder()
@@ -72,7 +73,7 @@ module.exports = {
         },
         {
           name: `monto (sats)`,
-          value: `${amount.value}`,
+          value: `${formatter(0,0).format(amount.value)}`,
         },
       ]);
 


### PR DESCRIPTION
Use the formatter to avoid confusion when showing an invoice

It has happened before that some people paid an invoice thinking it was a lower value. For example if you have 11111 it is hard to tell if it is one thousand or eleven thousand. After this change it will be shown as 11,111 which is much clearer. This commit also adds *.swp to the gitignore, have some mercy for the vim users.